### PR TITLE
Fix GitHub Actions detection

### DIFF
--- a/beanstalk-deploy.js
+++ b/beanstalk-deploy.js
@@ -4,7 +4,7 @@
 const awsApiRequest = require('./aws-api-request');
 const fs = require('fs');
 
-const IS_GITHUB_ACTION = !!process.env.GITHUB_ACTION;
+const IS_GITHUB_ACTION = !!process.env.GITHUB_ACTIONS;
 
 if (IS_GITHUB_ACTION) {
     console.error = msg => console.log(`::error::${msg}`);


### PR DESCRIPTION
Use GITHUB_ACTIONS environment variable for detecting GitHub Actions, as it appears they are not always setting an ID.